### PR TITLE
Refactor mobile sync logic for HealthKit integration

### DIFF
--- a/LifeTrackerX/Managers/HealthManager.swift
+++ b/LifeTrackerX/Managers/HealthManager.swift
@@ -31,7 +31,7 @@ class HealthManager: ObservableObject {
         HKObjectType.quantityType(forIdentifier: .waistCircumference)!
     ]
     
-    // Add a dictionary to track Apple Health sample UUIDs
+    // Add a dictionary to track Apple Health sample UUIDs (deprecated in favor of StatEntry.uuid)
     private var healthKitSampleMap: [UUID: String] = [:]
     
     init() {
@@ -394,7 +394,8 @@ class HealthManager: ObservableObject {
     
     // Function to get the HealthKit sample UUID for a StatEntry
     func getHealthKitSampleUUID(for entry: StatEntry) -> String? {
-        return healthKitSampleMap[entry.id]
+        // Prefer the persisted uuid stored on the entry
+        return entry.uuid ?? healthKitSampleMap[entry.id]
     }
     
     // Function to sync with HealthKit and handle deletions
@@ -431,46 +432,70 @@ class HealthManager: ObservableObject {
             }
             
             // Convert the sample to a StatEntry
-            let entry: StatEntry
+            var entry: StatEntry
             switch type {
             case .weight:
                 let weightInKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
                 entry = StatEntry(
+                    id: UUID(),
+                    uuid: sample.uuid.uuidString,
                     date: sample.startDate,
                     value: weightInKg,
                     type: .weight,
-                    source: .appleHealth
+                    source: .appleHealth,
+                    lastUpdatedAt: sample.startDate,
+                    syncedWithHealth: true,
+                    syncedWithBackend: false,
+                    isDeleted: false
                 )
             case .height:
                 let heightInCm = sample.quantity.doubleValue(for: HKUnit.meterUnit(with: .centi))
                 entry = StatEntry(
+                    id: UUID(),
+                    uuid: sample.uuid.uuidString,
                     date: sample.startDate,
                     value: heightInCm,
                     type: .height,
-                    source: .appleHealth
+                    source: .appleHealth,
+                    lastUpdatedAt: sample.startDate,
+                    syncedWithHealth: true,
+                    syncedWithBackend: false,
+                    isDeleted: false
                 )
             case .bodyFat:
                 let bodyFatDecimal = sample.quantity.doubleValue(for: HKUnit.percent())
                 let bodyFatPercentage = bodyFatDecimal * 100.0
                 entry = StatEntry(
+                    id: UUID(),
+                    uuid: sample.uuid.uuidString,
                     date: sample.startDate,
                     value: bodyFatPercentage,
                     type: .bodyFat,
-                    source: .appleHealth
+                    source: .appleHealth,
+                    lastUpdatedAt: sample.startDate,
+                    syncedWithHealth: true,
+                    syncedWithBackend: false,
+                    isDeleted: false
                 )
             case .waist:
                 let waistInCm = sample.quantity.doubleValue(for: HKUnit.meterUnit(with: .centi))
                 entry = StatEntry(
+                    id: UUID(),
+                    uuid: sample.uuid.uuidString,
                     date: sample.startDate,
                     value: waistInCm,
                     type: .waist,
-                    source: .appleHealth
+                    source: .appleHealth,
+                    lastUpdatedAt: sample.startDate,
+                    syncedWithHealth: true,
+                    syncedWithBackend: false,
+                    isDeleted: false
                 )
             default:
                 continue
             }
             
-            // Store the HealthKit sample UUID
+            // Store the HealthKit sample UUID for backward compatibility
             healthKitSampleMap[entry.id] = sample.uuid.uuidString
             
             // Add or update the entry (this will automatically sync to backend)

--- a/LifeTrackerX/Models/StatEntry.swift
+++ b/LifeTrackerX/Models/StatEntry.swift
@@ -19,18 +19,74 @@ enum StatSource: String, Codable, CaseIterable {
 
 struct StatEntry: Identifiable, Codable {
     var id: UUID
+    var uuid: String? // Apple Health UUID or server UUID
     var date: Date
     var value: Double
     var type: StatType
     var source: StatSource
-    var backendId: Int? // Backend database ID for sync operations
+    var backendId: Int? // Legacy backend database ID for sync operations
+    var lastUpdatedAt: Date
+    var syncedWithHealth: Bool
+    var syncedWithBackend: Bool
+    var isDeleted: Bool
     
-    init(id: UUID = UUID(), date: Date, value: Double, type: StatType, source: StatSource = .manual, backendId: Int? = nil) {
+    init(
+        id: UUID = UUID(),
+        uuid: String? = nil,
+        date: Date,
+        value: Double,
+        type: StatType,
+        source: StatSource = .manual,
+        backendId: Int? = nil,
+        lastUpdatedAt: Date = Date(),
+        syncedWithHealth: Bool = false,
+        syncedWithBackend: Bool = false,
+        isDeleted: Bool = false
+    ) {
         self.id = id
+        self.uuid = uuid
         self.date = date
         self.value = value
         self.type = type
         self.source = source
         self.backendId = backendId
+        self.lastUpdatedAt = lastUpdatedAt
+        self.syncedWithHealth = syncedWithHealth
+        self.syncedWithBackend = syncedWithBackend
+        self.isDeleted = isDeleted
+    }
+    
+    private enum CodingKeys: String, CodingKey {
+        case id, uuid, date, value, type, source, backendId, lastUpdatedAt, syncedWithHealth, syncedWithBackend, isDeleted
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.value = try container.decode(Double.self, forKey: .value)
+        self.type = try container.decode(StatType.self, forKey: .type)
+        self.source = try container.decode(StatSource.self, forKey: .source)
+        self.backendId = try container.decodeIfPresent(Int.self, forKey: .backendId)
+        self.lastUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .lastUpdatedAt) ?? Date()
+        self.syncedWithHealth = try container.decodeIfPresent(Bool.self, forKey: .syncedWithHealth) ?? false
+        self.syncedWithBackend = try container.decodeIfPresent(Bool.self, forKey: .syncedWithBackend) ?? false
+        self.isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted) ?? false
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(date, forKey: .date)
+        try container.encode(value, forKey: .value)
+        try container.encode(type, forKey: .type)
+        try container.encode(source, forKey: .source)
+        try container.encodeIfPresent(backendId, forKey: .backendId)
+        try container.encode(lastUpdatedAt, forKey: .lastUpdatedAt)
+        try container.encode(syncedWithHealth, forKey: .syncedWithHealth)
+        try container.encode(syncedWithBackend, forKey: .syncedWithBackend)
+        try container.encode(isDeleted, forKey: .isDeleted)
     }
 }

--- a/LifeTrackerX/Models/StatType.swift
+++ b/LifeTrackerX/Models/StatType.swift
@@ -95,6 +95,54 @@ enum StatType: String, Codable, CaseIterable, Identifiable, CustomStringConverti
         }
     }
     
+    // Backend string mapping (mobile sync)
+    var backendName: String {
+        switch self {
+        case .weight: return "weight"
+        case .height: return "height"
+        case .bodyFat: return "body_fat"
+        case .waist: return "waist"
+        case .bicep: return "bicep"
+        case .chest: return "chest"
+        case .thigh: return "thigh"
+        case .shoulder: return "shoulder"
+        case .glutes: return "glutes"
+        case .calf: return "calf"
+        case .neck: return "neck"
+        case .forearm: return "forearm"
+        case .bmi: return "bmi"
+        case .lbm: return "lbm"
+        case .fm: return "fm"
+        case .ffmi: return "ffmi"
+        case .bmr: return "bmr"
+        case .bsa: return "bsa"
+        }
+    }
+    
+    static func fromBackendName(_ name: String) -> StatType? {
+        switch name.lowercased() {
+        case "weight": return .weight
+        case "height": return .height
+        case "body_fat", "bodyfat": return .bodyFat
+        case "waist": return .waist
+        case "bicep": return .bicep
+        case "chest": return .chest
+        case "thigh": return .thigh
+        case "shoulder": return .shoulder
+        case "glutes": return .glutes
+        case "calf": return .calf
+        case "neck": return .neck
+        case "forearm": return .forearm
+        case "bmi": return .bmi
+        case "lbm": return .lbm
+        case "fm": return .fm
+        case "ffmi": return .ffmi
+        case "bmr": return .bmr
+        case "bsa": return .bsa
+        default: return nil
+        }
+    }
+    
     var description: String {
         return self.rawValue
     }


### PR DESCRIPTION
Enhance `StatEntry` model and HealthKit integration to support robust mobile sync with UUIDs, timestamps, and soft deletes.

The previous sync system was buggy and not seamless, particularly between the app, HealthKit, and the backend. This update lays the groundwork for a more reliable offline-first and conflict-resolving sync architecture by extending data models and HealthKit processing to align with the backend's enhanced mobile sync features.

---
<a href="https://cursor.com/background-agent?bcId=bc-d77c56a8-7c4a-44f1-a408-e8d06f40c5ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d77c56a8-7c4a-44f1-a408-e8d06f40c5ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

