### PR TITLE
Refactor mobile sync logic for HealthKit integration

### DIFF
--- a/LifeTrackerX/Managers/HealthManager.swift
+++ b/LifeTrackerX/Managers/HealthManager.swift
@@ -428,18 +428,19 @@ class HealthManager: ObservableObject {
         // Create a set of sample UUIDs from HealthKit
         let currentSampleUUIDs = Set(samples.map { $0.uuid.uuidString })
         
-        // Find entries that need to be deleted (exist in our app but not in HealthKit)
-        let entriesToDelete = existingEntries.filter { entry in
+        // Mark entries that no longer exist in HealthKit as deleted instead of removing
+        let entriesToMarkDeleted = existingEntries.filter { entry in
             if let sampleUUID = getHealthKitSampleUUID(for: entry) {
                 return !currentSampleUUIDs.contains(sampleUUID)
             }
-            return true // If we don't have a sample UUID, delete it
+            return true // If we don't have a sample UUID, mark as deleted
         }
         
-        // Delete entries that no longer exist in HealthKit
-        for entry in entriesToDelete {
-            print("🗑️ Deleting entry that no longer exists in HealthKit: \(entry.type) from \(entry.date)")
-            historyManager.removeEntry(entry)
+        for entry in entriesToMarkDeleted {
+            var softDeleted = entry
+            softDeleted.isDeleted = true
+            softDeleted.lastUpdatedAt = Date()
+            historyManager.updateEntry(softDeleted)
         }
         
         // Add or update entries from HealthKit
@@ -455,29 +456,28 @@ class HealthManager: ObservableObject {
                 continue
             }
             
-            let entry: StatEntry
+            var entry: StatEntry
             switch type {
             case .weight:
                 let weightInKg = sample.quantity.doubleValue(for: HKUnit.gramUnit(with: .kilo))
-                entry = StatEntry(date: sample.startDate, value: weightInKg, type: .weight, source: .appleHealth)
+                entry = StatEntry(date: sample.startDate, value: weightInKg, type: .weight, source: .appleHealth, uuid: sample.uuid.uuidString, lastUpdatedAt: sample.endDate)
             case .height:
                 let heightInCm = sample.quantity.doubleValue(for: HKUnit.meterUnit(with: .centi))
-                entry = StatEntry(date: sample.startDate, value: heightInCm, type: .height, source: .appleHealth)
+                entry = StatEntry(date: sample.startDate, value: heightInCm, type: .height, source: .appleHealth, uuid: sample.uuid.uuidString, lastUpdatedAt: sample.endDate)
             case .bodyFat:
                 let bodyFatDecimal = sample.quantity.doubleValue(for: HKUnit.percent())
                 let bodyFatPercentage = bodyFatDecimal * 100.0
-                entry = StatEntry(date: sample.startDate, value: bodyFatPercentage, type: .bodyFat, source: .appleHealth)
+                entry = StatEntry(date: sample.startDate, value: bodyFatPercentage, type: .bodyFat, source: .appleHealth, uuid: sample.uuid.uuidString, lastUpdatedAt: sample.endDate)
             case .waist:
                 let waistInCm = sample.quantity.doubleValue(for: HKUnit.meterUnit(with: .centi))
-                entry = StatEntry(date: sample.startDate, value: waistInCm, type: .waist, source: .appleHealth)
+                entry = StatEntry(date: sample.startDate, value: waistInCm, type: .waist, source: .appleHealth, uuid: sample.uuid.uuidString, lastUpdatedAt: sample.endDate)
             default:
                 continue
             }
             
             let existingEntry = existingEntries.first { existing in
-                Calendar.current.isDate(existing.date, inSameDayAs: entry.date) &&
-                existing.type == entry.type &&
-                existing.source == entry.source
+                (existing.uuid != nil && existing.uuid == sample.uuid.uuidString) ||
+                (Calendar.current.isDate(existing.date, inSameDayAs: entry.date) && existing.type == entry.type && existing.source == entry.source)
             }
             
             if existingEntry != nil {
@@ -486,6 +486,7 @@ class HealthManager: ObservableObject {
             }
             
             healthKitSampleMap[entry.id] = sample.uuid.uuidString
+            entry.syncedWithHealth = true
             newEntries.append(entry)
             addedCount += 1
         }
@@ -494,7 +495,7 @@ class HealthManager: ObservableObject {
             historyManager.addEntries(newEntries)
         }
         
-        print("📊 Sync completed for \(type): Added \(addedCount) entries, Skipped \(skippedCount) duplicates, Deleted \(entriesToDelete.count) entries")
+        print("📊 Sync completed for \(type): Added \(addedCount) entries, Skipped \(skippedCount) duplicates, Marked \(entriesToMarkDeleted.count) deleted")
         completion(true)
     }
     

--- a/LifeTrackerX/Managers/MetricSyncManager.swift
+++ b/LifeTrackerX/Managers/MetricSyncManager.swift
@@ -66,7 +66,9 @@ class MetricSyncManager: ObservableObject {
             existing.statType == operation.statType &&
             existing.date == operation.date &&
             existing.value == operation.value &&
-            existing.isAppleHealth == operation.isAppleHealth
+            existing.isAppleHealth == operation.isAppleHealth &&
+            existing.uuid == operation.uuid &&
+            existing.isDeleted == operation.isDeleted
         }
         
         if isDuplicate {
@@ -142,6 +144,24 @@ class MetricSyncManager: ObservableObject {
     }
     
     private func entryExistsOnBackend(_ operation: SyncOperation) async -> Bool {
+        // Prefer v2 lookup by UUID if available
+        if let uuid = operation.uuid {
+            do {
+                let path = "/api/metrics?id=\(uuid)"
+                let (data, response) = try await networkManager.makeAuthenticatedRawRequest(path, method: "GET")
+                if (200...299).contains(response.statusCode) {
+                    // If any entries are returned, it exists
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let entries = json["entries"] as? [Any] {
+                        return !entries.isEmpty
+                    }
+                }
+            } catch {
+                logger.error("V2 existence check failed: \(error.localizedDescription)")
+            }
+        }
+        
+        // Legacy fallback
         do {
             let response: MetricsListResponse = try await networkManager.makeAuthenticatedRequest(
                 "/api/metrics",
@@ -173,7 +193,13 @@ class MetricSyncManager: ObservableObject {
                     value: operation.value,
                     type: operation.statType,
                     source: operation.isAppleHealth ? .appleHealth : .manual,
-                    backendId: operation.backendId
+                    backendId: operation.backendId,
+                    uuid: operation.uuid,
+                    lastUpdatedAt: operation.clientLastUpdatedAt,
+                    syncedWithHealth: false,
+                    syncedWithBackend: false,
+                    isDeleted: operation.isDeleted,
+                    unit: operation.unit
                 ),
                 retryCount: operation.retryCount + 1
             )
@@ -188,8 +214,31 @@ class MetricSyncManager: ObservableObject {
         }
     }
     
-    // MARK: - API Operations
+    // MARK: - API Operations (V2 preferred with legacy fallback)
     private func createMetric(_ operation: SyncOperation) async throws {
+        // Prefer v2 payload
+        let v2 = CreateMetricV2Request(
+            id: operation.uuid,
+            metric_type: operation.statType.rawValue,
+            metric_type_id: BackendMetricType.from(operation.statType)?.rawValue,
+            value: operation.value,
+            unit: operation.unit,
+            timestamp: DateCoding.iso8601.string(from: operation.date),
+            date: nil,
+            source: operation.isAppleHealth ? "apple_health" : "app"
+        )
+        let v2Data = try JSONEncoder().encode(v2)
+        do {
+            let (data, response) = try await networkManager.makeAuthenticatedRawRequest("/api/metrics", method: "POST", body: v2Data)
+            guard (200...299).contains(response.statusCode) else { throw AuthError.unknown }
+            // Success
+            logger.info("Successfully created metric (v2): \(operation.statType.rawValue)")
+            return
+        } catch {
+            logger.error("Create v2 failed, falling back to legacy: \(error.localizedDescription)")
+        }
+        
+        // Legacy fallback
         let entry = StatEntry(
             id: operation.entryId,
             date: operation.date,
@@ -197,69 +246,94 @@ class MetricSyncManager: ObservableObject {
             type: operation.statType,
             source: operation.isAppleHealth ? .appleHealth : .manual
         )
-        
         let request = CreateMetricRequest(entry: entry)
         let requestData = try JSONEncoder().encode(request)
-        
         let response: MetricResponse = try await networkManager.makeAuthenticatedRequest(
             "/api/metrics",
             method: "POST",
             body: requestData
         )
-        
         if !response.success {
-            throw NSError(domain: "MetricSync", code: -1, userInfo: [
-                NSLocalizedDescriptionKey: response.error ?? "Unknown error"
-            ])
-        }
-        
-        logger.info("Successfully created metric: \(operation.statType.rawValue)")
+            throw NSError(domain: "MetricSync", code: -1, userInfo: [NSLocalizedDescriptionKey: response.error ?? "Unknown error"]) }
+        logger.info("Successfully created metric (legacy): \(operation.statType.rawValue)")
     }
     
     private func updateMetric(_ operation: SyncOperation) async throws {
+        // Prefer v2 update using UUID if available
+        if let uuid = operation.uuid {
+            let v2 = UpdateMetricV2Request(
+                value: operation.value,
+                unit: operation.unit,
+                timestamp: DateCoding.iso8601.string(from: operation.date),
+                source: operation.isAppleHealth ? "apple_health" : "app",
+                client_last_updated_at: DateCoding.iso8601.string(from: operation.clientLastUpdatedAt)
+            )
+            let v2Data = try JSONEncoder().encode(v2)
+            do {
+                let path = "/api/metrics/\(uuid)"
+                let (_, response) = try await networkManager.makeAuthenticatedRawRequest(path, method: "PUT", body: v2Data)
+                switch response.statusCode {
+                case 200...299:
+                    logger.info("Successfully updated metric (v2): \(operation.statType.rawValue)")
+                    return
+                case 409, 410:
+                    // Conflict or Gone - pull changes then treat as success
+                    await StatsHistoryManager.shared.loadMetricsFromServer()
+                    logger.info("Resolved conflict/gone by syncing from server for: \(operation.statType.rawValue)")
+                    return
+                default:
+                    throw AuthError.unknown
+                }
+            } catch {
+                logger.error("Update v2 failed, falling back to legacy: \(error.localizedDescription)")
+            }
+        }
+        
+        // Legacy fallback by backend ID or UUID
         let entry = StatEntry(
             id: operation.entryId,
             date: operation.date,
             value: operation.value,
             type: operation.statType,
-            source: operation.isAppleHealth ? .appleHealth : .manual
+            source: operation.isAppleHealth ? .appleHealth : .manual,
+            backendId: operation.backendId
         )
-        
         let request = UpdateMetricRequest(entry: entry)
         let requestData = try JSONEncoder().encode(request)
-        
-        // Use backend ID if available, otherwise use UUID
         let identifier = entry.backendId?.description ?? operation.entryId.uuidString
         let response: MetricResponse = try await networkManager.makeAuthenticatedRequest(
             "/api/metrics/\(identifier)",
             method: "PUT",
             body: requestData
         )
-        
         if !response.success {
-            throw NSError(domain: "MetricSync", code: -1, userInfo: [
-                NSLocalizedDescriptionKey: response.error ?? "Unknown error"
-            ])
-        }
-        
-        logger.info("Successfully updated metric: \(operation.statType.rawValue)")
+            throw NSError(domain: "MetricSync", code: -1, userInfo: [NSLocalizedDescriptionKey: response.error ?? "Unknown error"]) }
+        logger.info("Successfully updated metric (legacy): \(operation.statType.rawValue)")
     }
     
     private func deleteMetric(_ operation: SyncOperation) async throws {
-        // Use backend ID if available, otherwise use UUID
+        // Prefer v2 soft delete by UUID
+        if let uuid = operation.uuid {
+            do {
+                let path = "/api/metrics/\(uuid)"
+                let (_, response) = try await networkManager.makeAuthenticatedRawRequest(path, method: "DELETE", body: nil)
+                guard (200...299).contains(response.statusCode) else { throw AuthError.unknown }
+                logger.info("Successfully deleted metric (v2 soft): \(operation.statType.rawValue)")
+                return
+            } catch {
+                logger.error("Delete v2 failed, falling back to legacy: \(error.localizedDescription)")
+            }
+        }
+        
+        // Legacy fallback by backend ID or UUID
         let identifier = operation.backendId?.description ?? operation.entryId.uuidString
         let response: MetricResponse = try await networkManager.makeAuthenticatedRequest(
             "/api/metrics/\(identifier)",
             method: "DELETE"
         )
-        
         if !response.success {
-            throw NSError(domain: "MetricSync", code: -1, userInfo: [
-                NSLocalizedDescriptionKey: response.error ?? "Unknown error"
-            ])
-        }
-        
-        logger.info("Successfully deleted metric: \(operation.statType.rawValue)")
+            throw NSError(domain: "MetricSync", code: -1, userInfo: [NSLocalizedDescriptionKey: response.error ?? "Unknown error"]) }
+        logger.info("Successfully deleted metric (legacy): \(operation.statType.rawValue)")
     }
     
     // MARK: - Public Interface
@@ -320,7 +394,7 @@ class MetricSyncManager: ObservableObject {
         return pendingOperations
     }
     
-    // MARK: - Data Fetching
+    // MARK: - Data Fetching (Legacy list for initial load)
     func fetchUserMetrics() async throws -> [StatEntry] {
         logger.info("Fetching user metrics from server")
         
@@ -336,9 +410,10 @@ class MetricSyncManager: ObservableObject {
         }
         
         let entries = response.entries.map { metric in
-            StatEntry(
+            let parsedDate = Self.isoDateFormatter.date(from: metric.date) ?? Self.dateOnlyFormatter.date(from: metric.date) ?? Date()
+            return StatEntry(
                 id: UUID(), // Generate new UUID for local storage
-                date: Self.dateFormatter.date(from: metric.date) ?? Date(),
+                date: parsedDate,
                 value: Double(metric.value) ?? 0.0, // Convert string to Double
                 type: BackendMetricType(rawValue: metric.metric_type_id)?.toStatType() ?? .weight,
                 source: metric.is_apple_health ? .appleHealth : .manual,
@@ -350,9 +425,16 @@ class MetricSyncManager: ObservableObject {
         return entries
     }
     
-    private static let dateFormatter: DateFormatter = {
+    private static let isoDateFormatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        f.timeZone = TimeZone(abbreviation: "UTC")
+        return f
+    }()
+    
+    private static let dateOnlyFormatter: DateFormatter = {
         let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
+        formatter.dateFormat = "yyyy-MM-dd"
         formatter.timeZone = TimeZone(abbreviation: "UTC")
         return formatter
     }()

--- a/LifeTrackerX/Managers/NetworkManager.swift
+++ b/LifeTrackerX/Managers/NetworkManager.swift
@@ -76,4 +76,40 @@ class NetworkManager {
             throw AuthError.networkError(error)
         }
     }
+    
+    // Raw request helper for endpoints where we need full control (e.g., v2 sync)
+    func makeAuthenticatedRawRequest(_ endpoint: String, method: String = "GET", body: Data? = nil) async throws -> (Data, HTTPURLResponse) {
+        logger.debug("Making authenticated RAW request to: \(endpoint) with method: \(method)")
+        
+        guard let accessToken = secureStorage.getAccessToken() else {
+            throw AuthError.unauthorized
+        }
+        
+        let headers = [
+            "Authorization": "Bearer \(accessToken)"
+        ]
+        
+        guard let request = authService.createRequest(endpoint, method: method, body: body, headers: headers) else {
+            throw AuthError.invalidURL
+        }
+        
+        let (responseData, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+        
+        // If unauthorized, attempt refresh and retry once
+        if httpResponse.statusCode == 401 {
+            if let refreshToken = secureStorage.getRefreshToken(), let deviceId = secureStorage.getDeviceId() {
+                let refreshResponse = try await authService.refreshToken(refreshToken: refreshToken, deviceId: deviceId)
+                secureStorage.saveAccessToken(refreshResponse.accessToken)
+                secureStorage.saveRefreshToken(refreshResponse.refreshToken)
+                return try await makeAuthenticatedRawRequest(endpoint, method: method, body: body)
+            } else {
+                throw AuthError.unauthorized
+            }
+        }
+        
+        return (responseData, httpResponse)
+    }
 } 

--- a/LifeTrackerX/Managers/StatsHistoryManager.swift
+++ b/LifeTrackerX/Managers/StatsHistoryManager.swift
@@ -9,6 +9,7 @@ class StatsHistoryManager: ObservableObject {
     // Add a refresh trigger to force view updates
     @Published var refreshTrigger: UUID = UUID()
     private let saveKey = "StatsHistory"
+    private let lastSyncKey = "MetricsLastServerSyncTimestamp"
     
     // Flag to track if Apple Health entries have been synced to backend
     private var appleHealthEntriesSynced = false
@@ -32,6 +33,26 @@ class StatsHistoryManager: ObservableObject {
         }
     }
     
+    // Last server sync timestamp for incremental sync
+    var lastServerSyncTimestamp: Date? {
+        get {
+            if let isoString = UserDefaults.standard.string(forKey: lastSyncKey) {
+                if let date = DateCoding.iso8601.date(from: isoString) ?? DateCoding.iso8601NoFraction.date(from: isoString) {
+                    return date
+                }
+            }
+            return nil
+        }
+        set {
+            if let newValue = newValue {
+                let iso = DateCoding.iso8601.string(from: newValue)
+                UserDefaults.standard.set(iso, forKey: lastSyncKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: lastSyncKey)
+            }
+        }
+    }
+    
     // Function to sync all manual entries to Apple Health
     func syncManualEntriesToHealthKit() {
         guard healthManager.isWriteAuthorized else { 
@@ -42,7 +63,7 @@ class StatsHistoryManager: ObservableObject {
         print("📤 Starting sync of all manual entries to Apple Health")
         
         // Get all manual entries that aren't BMI (since BMI is calculated)
-        let manualEntries = entries.filter { $0.source == .manual && $0.type != .bmi }
+        let manualEntries = entries.filter { $0.source == .manual && $0.type != .bmi && !$0.isDeleted }
         print("📤 Found \(manualEntries.count) manual entries to sync")
         
         for entry in manualEntries {
@@ -67,7 +88,7 @@ class StatsHistoryManager: ObservableObject {
         print("📤 Starting sync of Apple Health entries to backend")
         
         // Get all Apple Health entries that aren't calculated
-        let appleHealthEntries = entries.filter { $0.source == .appleHealth && !$0.type.isCalculated }
+        let appleHealthEntries = entries.filter { $0.source == .appleHealth && !$0.type.isCalculated && !$0.isDeleted }
         print("📤 Found \(appleHealthEntries.count) Apple Health entries to sync to backend")
         
         for entry in appleHealthEntries {
@@ -85,7 +106,7 @@ class StatsHistoryManager: ObservableObject {
         print("📤 Starting sync of all entries to backend database")
         
         // Get all non-calculated entries
-        let entriesToSync = entries.filter { !$0.type.isCalculated }
+        let entriesToSync = entries.filter { !$0.type.isCalculated && !$0.isDeleted }
         print("📤 Found \(entriesToSync.count) entries to sync to backend")
         
         Task { @MainActor in
@@ -103,9 +124,9 @@ class StatsHistoryManager: ObservableObject {
         print("🔄 Recalculating all derived values...")
         
         // Get all entries sorted by date
-        let weightEntries = entries.filter { $0.type == .weight }.sorted { $0.date < $1.date }
-        let heightEntries = entries.filter { $0.type == .height }.sorted { $0.date < $1.date }
-        let bodyFatEntries = entries.filter { $0.type == .bodyFat }.sorted { $0.date < $1.date }
+        let weightEntries = entries.filter { $0.type == .weight && !$0.isDeleted }.sorted { $0.date < $1.date }
+        let heightEntries = entries.filter { $0.type == .height && !$0.isDeleted }.sorted { $0.date < $1.date }
+        let bodyFatEntries = entries.filter { $0.type == .bodyFat && !$0.isDeleted }.sorted { $0.date < $1.date }
         
         // Remove all existing calculated entries
         entries.removeAll { $0.type.isCalculated }
@@ -194,18 +215,23 @@ class StatsHistoryManager: ObservableObject {
             return
         }
         
+        var newEntry = entry
+        newEntry.lastUpdatedAt = Date()
+        newEntry.syncedWithBackend = false
+        
         // Only replace if the entry has the same date, type and source
         if let index = entries.firstIndex(where: {
-            Calendar.current.isDate($0.date, inSameDayAs: entry.date) &&
-            $0.type == entry.type &&
-            $0.source == entry.source
+            Calendar.current.isDate($0.date, inSameDayAs: newEntry.date) &&
+            $0.type == newEntry.type &&
+            $0.source == newEntry.source &&
+            !$0.isDeleted
         }) {
-            entries[index] = entry
+            entries[index] = newEntry
         } else {
-            entries.append(entry)
+            entries.append(newEntry)
             
             // If this is a new Apple Health entry, reset the sync flag
-            if entry.source == .appleHealth {
+            if newEntry.source == .appleHealth {
                 appleHealthEntriesSynced = false
             }
         }
@@ -214,26 +240,26 @@ class StatsHistoryManager: ObservableObject {
         entries.sort { $0.date > $1.date }
         
         // If this is a weight, height, or body fat entry, recalculate all derived values
-        if entry.type == .weight || entry.type == .height || entry.type == .bodyFat {
+        if newEntry.type == .weight || newEntry.type == .height || newEntry.type == .bodyFat {
             recalculateAllDerivedValues()
         } else {
             saveEntries()
         }
         
         // Sync to backend database (for all non-calculated metrics, but not Apple Health entries during import)
-        if !entry.type.isCalculated && entry.source != .appleHealth {
-            print("📤 Syncing entry to backend: \(entry.type)")
+        if !newEntry.type.isCalculated && newEntry.source != .appleHealth && !newEntry.isDeleted {
+            print("📤 Syncing entry to backend: \(newEntry.type)")
             Task { @MainActor in
-                metricSyncManager.syncEntry(entry, operation: .create)
+                metricSyncManager.syncEntry(newEntry, operation: .create)
             }
         }
         
         // If this is a manual entry and not from Apple Health, sync to HealthKit
-        if entry.source == .manual && !entry.type.isCalculated {
+        if newEntry.source == .manual && !newEntry.type.isCalculated {
             if healthManager.isWriteAuthorized {
-                healthManager.saveToHealthKit(entry) { success, error in
+                healthManager.saveToHealthKit(newEntry) { success, error in
                     if success {
-                        print("✅ Synced \(entry.type) to Apple Health")
+                        print("✅ Synced \(newEntry.type) to Apple Health")
                     } else if let error = error {
                         print("❌ Error syncing to Apple Health: \(error.localizedDescription)")
                     }
@@ -255,11 +281,13 @@ class StatsHistoryManager: ObservableObject {
 
         var hasAppleHealthEntries = false
         
-        for entry in newEntries {
+        for var entry in newEntries {
+            // Ensure sync metadata exists
+            entry.lastUpdatedAt = entry.lastUpdatedAt
+            
             if let index = entries.firstIndex(where: {
-                Calendar.current.isDate($0.date, inSameDayAs: entry.date) &&
-                $0.type == entry.type &&
-                $0.source == entry.source
+                ($0.uuid != nil && $0.uuid == entry.uuid) ||
+                (Calendar.current.isDate($0.date, inSameDayAs: entry.date) && $0.type == entry.type && $0.source == entry.source)
             }) {
                 entries[index] = entry
             } else {
@@ -290,32 +318,34 @@ class StatsHistoryManager: ObservableObject {
             return
         }
         
-        entries.removeAll { $0.id == entry.id }
-        
-        // Sync to backend database (for all non-calculated metrics)
-        if !entry.type.isCalculated {
-            print("📤 Syncing deleted entry to backend: \(entry.type)")
-            Task { @MainActor in
-                metricSyncManager.syncEntry(entry, operation: .delete)
-            }
-        }
-        
-        // If this is a weight or height entry, recalculate BMI entries
-        if entry.type == .weight || entry.type == .height {
-            recalculateAllDerivedValues()
-        }
-        
-        // If this was a manual entry, also delete from HealthKit
-        if entry.source == .manual && healthManager.isWriteAuthorized {
-            healthManager.deleteFromHealthKit(entry) { success, error in
-                if success {
-                    print("Successfully deleted \(entry.type) from Apple Health")
-                } else if let error = error {
-                    print("Error deleting from Apple Health: \(error.localizedDescription)")
+        // Soft delete: mark as deleted but keep for sync
+        if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            entries[index].isDeleted = true
+            entries[index].lastUpdatedAt = Date()
+            entries[index].syncedWithBackend = false
+            
+            let deletedEntry = entries[index]
+            
+            // Sync to backend database (for all non-calculated metrics)
+            if !deletedEntry.type.isCalculated {
+                print("📤 Syncing deleted entry to backend: \(deletedEntry.type)")
+                Task { @MainActor in
+                    metricSyncManager.syncEntry(deletedEntry, operation: .delete)
                 }
             }
-        } else if entry.source == .manual && !healthManager.isWriteAuthorized {
-            print("⚠️ Cannot delete from HealthKit - write access not available")
+            
+            // If this was a manual entry that we previously wrote to HealthKit, attempt to delete it there
+            if deletedEntry.source == .manual && healthManager.isWriteAuthorized && deletedEntry.syncedWithHealth {
+                healthManager.deleteFromHealthKit(deletedEntry) { success, error in
+                    if success {
+                        print("Successfully deleted \(deletedEntry.type) from Apple Health")
+                    } else if let error = error {
+                        print("Error deleting from Apple Health: \(error.localizedDescription)")
+                    }
+                }
+            } else if deletedEntry.source == .manual && !healthManager.isWriteAuthorized {
+                print("⚠️ Cannot delete from HealthKit - write access not available")
+            }
         }
         
         saveEntries()
@@ -333,19 +363,30 @@ class StatsHistoryManager: ObservableObject {
         print("📝 Updating entry: type=\(entry.type), source=\(entry.source), value=\(entry.value)")
         
         if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            var updatedEntry = entry
+            updatedEntry.lastUpdatedAt = Date()
+            updatedEntry.syncedWithBackend = false
+            
             let oldEntry = entries[index]
-            entries[index] = entry
+            entries[index] = updatedEntry
             
             // Sync to backend database (for all non-calculated metrics)
-            if !entry.type.isCalculated {
-                print("📤 Syncing updated entry to backend: \(entry.type)")
-                Task { @MainActor in
-                    metricSyncManager.syncEntry(entry, operation: .update)
+            if !updatedEntry.type.isCalculated {
+                if updatedEntry.isDeleted {
+                    print("📤 Syncing soft-deleted entry to backend: \(updatedEntry.type)")
+                    Task { @MainActor in
+                        metricSyncManager.syncEntry(updatedEntry, operation: .delete)
+                    }
+                } else {
+                    print("📤 Syncing updated entry to backend: \(updatedEntry.type)")
+                    Task { @MainActor in
+                        metricSyncManager.syncEntry(updatedEntry, operation: .update)
+                    }
                 }
             }
             
             // If this is a manual entry and we're authorized, update in HealthKit
-            if oldEntry.source == .manual && entry.type != .bmi && healthManager.isWriteAuthorized {
+            if oldEntry.source == .manual && updatedEntry.type != .bmi && healthManager.isWriteAuthorized {
                 print("📤 Syncing updated entry to Apple Health")
                 
                 // First delete the old entry from HealthKit
@@ -353,7 +394,7 @@ class StatsHistoryManager: ObservableObject {
                     if success {
                         print("✅ Successfully deleted old entry from Apple Health")
                         // Then save the new entry to HealthKit
-                        self.healthManager.saveToHealthKit(entry) { success, error in
+                        self.healthManager.saveToHealthKit(updatedEntry) { success, error in
                             if success {
                                 print("✅ Successfully saved updated entry to Apple Health")
                             } else if let error = error {
@@ -367,7 +408,7 @@ class StatsHistoryManager: ObservableObject {
             }
             
             // If this is a weight or height entry, recalculate BMI entries
-            if entry.type == .weight || entry.type == .height {
+            if updatedEntry.type == .weight || updatedEntry.type == .height {
                 recalculateAllDerivedValues()
             }
             
@@ -377,7 +418,7 @@ class StatsHistoryManager: ObservableObject {
     }
     
     func getLatestValue(for type: StatType) -> Double? {
-        let typeEntries = entries.filter { $0.type == type }
+        let typeEntries = entries.filter { $0.type == type && !$0.isDeleted }
         if let latest = typeEntries.sorted(by: { $0.date > $1.date }).first {
             return latest.value
         }
@@ -385,11 +426,11 @@ class StatsHistoryManager: ObservableObject {
     }
     
     func getEntries(for type: StatType) -> [StatEntry] {
-        return entries.filter { $0.type == type }.sorted(by: { $0.date > $1.date })
+        return entries.filter { $0.type == type && !$0.isDeleted }.sorted(by: { $0.date > $1.date })
     }
     
     func getEntries(for type: StatType, source: StatSource) -> [StatEntry] {
-        return entries.filter { $0.type == type && $0.source == source }.sorted(by: { $0.date > $1.date })
+        return entries.filter { $0.type == type && $0.source == source && !$0.isDeleted }.sorted(by: { $0.date > $1.date })
     }
     
     func getEntriesAt(date: Date) -> [StatEntry] {
@@ -399,7 +440,7 @@ class StatsHistoryManager: ObservableObject {
         
         for type in relevantTypes {
             // Find the most recent entry for this type on or before the given date
-            if let latestEntry = entries.filter({ $0.type == type && $0.date <= date })
+            if let latestEntry = entries.filter({ $0.type == type && $0.date <= date && !$0.isDeleted })
                 .sorted(by: { $0.date > $1.date })
                 .first {
                 result.append(latestEntry)
@@ -421,10 +462,10 @@ class StatsHistoryManager: ObservableObject {
            let decoded = try? JSONDecoder().decode([StatEntry].self, from: data) {
             entries = decoded
             print("📱 Loaded \(entries.count) total entries")
-            print("📱 Weight entries: \(entries.filter { $0.type == .weight }.count)")
-            print("📱 Height entries: \(entries.filter { $0.type == .height }.count)")
-            print("📱 BMI entries: \(entries.filter { $0.type == .bmi }.count)")
-            print("📱 Body Fat entries: \(entries.filter { $0.type == .bodyFat }.count)")
+            print("📱 Weight entries: \(entries.filter { $0.type == .weight && !$0.isDeleted }.count)")
+            print("📱 Height entries: \(entries.filter { $0.type == .height && !$0.isDeleted }.count)")
+            print("📱 BMI entries: \(entries.filter { $0.type == .bmi && !$0.isDeleted }.count)")
+            print("📱 Body Fat entries: \(entries.filter { $0.type == .bodyFat && !$0.isDeleted }.count)")
             
             // Recalculate BMI entries when loading data
             recalculateAllDerivedValues()
@@ -460,28 +501,126 @@ class StatsHistoryManager: ObservableObject {
         print("📱 Loading metrics from server...")
         
         do {
-            let serverEntries = try await MetricSyncManager.shared.fetchUserMetrics()
-            
-            // Update UI on main thread
-            await MainActor.run {
-                // Clear existing entries and add server entries
-                entries = serverEntries
+            if let since = lastServerSyncTimestamp {
+                let sinceParam = DateCoding.iso8601.string(from: since)
+                let url = "/api/metrics/sync/changes?since_timestamp=\(sinceParam)"
+                let (data, httpResponse) = try await NetworkManager.shared.makeAuthenticatedRawRequest(url, method: "GET")
+                guard (200...299).contains(httpResponse.statusCode) else {
+                    throw AuthError.unknown
+                }
+                let decoder = JSONDecoder()
+                let response = try decoder.decode(SyncChangesResponseV2.self, from: data)
                 
-                // Recalculate BMI entries
-                recalculateAllDerivedValues()
-                
-                // Save to local storage
-                saveEntries()
-                
-                // Trigger UI update
-                triggerUpdate()
+                await MainActor.run {
+                    for dto in response.entries {
+                        applyServerChange(dto)
+                    }
+                    // Save and update last sync time
+                    saveEntries()
+                    if let serverTime = DateCoding.iso8601.date(from: response.server_timestamp) ?? DateCoding.iso8601NoFraction.date(from: response.server_timestamp) {
+                        lastServerSyncTimestamp = serverTime
+                    }
+                    triggerUpdate()
+                }
+                print("📱 Successfully merged \(response.entries.count) changes from server")
+            } else {
+                // Fallback initial load using legacy endpoint
+                let serverEntries = try await MetricSyncManager.shared.fetchUserMetrics()
+                await MainActor.run {
+                    entries = serverEntries
+                    recalculateAllDerivedValues()
+                    saveEntries()
+                    triggerUpdate()
+                }
+                print("📱 Successfully loaded \(serverEntries.count) metrics from server")
             }
-            
-            print("📱 Successfully loaded \(serverEntries.count) metrics from server")
         } catch {
             print("❌ Failed to load metrics from server: \(error.localizedDescription)")
-            // Don't throw error - just log it and continue with empty data
-            // This allows the app to work even if the endpoint doesn't exist yet
+            // Don't throw error - just log it and continue with existing data
         }
+    }
+    
+    // Merge strategy per mobile sync rules
+    private func applyServerChange(_ dto: MobileMetricEntryDTO) {
+        // Map DTO to StatEntry
+        let metricTypeName = dto.metric_type?.lowercased()
+        let statType: StatType = {
+            if let id = dto.metric_type_id, let backendType = BackendMetricType(rawValue: id) { return backendType.toStatType() }
+            switch metricTypeName {
+            case "weight": return .weight
+            case "height": return .height
+            case "body_fat": return .bodyFat
+            case "waist": return .waist
+            case "bicep": return .bicep
+            case "chest": return .chest
+            case "thigh": return .thigh
+            case "shoulder": return .shoulder
+            case "glutes": return .glutes
+            case "calf": return .calf
+            case "neck": return .neck
+            case "forearm": return .forearm
+            default: return .weight
+            }
+        }()
+        
+        let source: StatSource = (dto.source == "apple_health") ? .appleHealth : .manual
+        
+        let timestampString = dto.timestamp ?? dto.date
+        let date: Date = {
+            if let ts = timestampString {
+                return DateCoding.iso8601.date(from: ts) ?? DateCoding.iso8601NoFraction.date(from: ts) ?? Date()
+            }
+            if let d = dto.date {
+                let fmt = DateFormatter()
+                fmt.dateFormat = "yyyy-MM-dd"
+                return fmt.date(from: d) ?? Date()
+            }
+            return Date()
+        }()
+        
+        let serverUpdatedAt: Date = {
+            if let lu = dto.last_updated_at {
+                return DateCoding.iso8601.date(from: lu) ?? DateCoding.iso8601NoFraction.date(from: lu) ?? Date()
+            }
+            return Date()
+        }()
+        
+        let isDeleted = dto.is_deleted ?? false
+        
+        // Find local entry by UUID or date/type/source
+        if let index = entries.firstIndex(where: { ($0.uuid == dto.id) || (Calendar.current.isDate($0.date, inSameDayAs: date) && $0.type == statType && $0.source == source) }) {
+            var local = entries[index]
+            // Conflict resolution: server wins if newer
+            if serverUpdatedAt > local.lastUpdatedAt || local.isDeleted {
+                local.value = dto.value
+                local.unit = dto.unit ?? local.unit
+                local.date = date
+                local.uuid = dto.id
+                local.lastUpdatedAt = serverUpdatedAt
+                local.isDeleted = isDeleted
+                local.syncedWithBackend = true
+                entries[index] = local
+            }
+        } else {
+            // New entry from server
+            var entry = StatEntry(
+                id: UUID(),
+                date: date,
+                value: dto.value,
+                type: statType,
+                source: source,
+                backendId: nil,
+                uuid: dto.id,
+                lastUpdatedAt: serverUpdatedAt,
+                syncedWithHealth: source == .appleHealth,
+                syncedWithBackend: true,
+                isDeleted: isDeleted,
+                unit: dto.unit
+            )
+            entries.append(entry)
+        }
+        
+        // Maintain calculated values after merging
+        // (We will recalculate at the end of batch in caller)
     }
 }

--- a/LifeTrackerX/Models/MetricSyncModels.swift
+++ b/LifeTrackerX/Models/MetricSyncModels.swift
@@ -71,6 +71,12 @@ struct SyncOperation: Codable, Identifiable {
     let retryCount: Int
     let backendId: Int?
     
+    // v2 sync fields
+    let uuid: String?
+    let clientLastUpdatedAt: Date
+    let isDeleted: Bool
+    let unit: String?
+    
     init(operationType: SyncOperationType, entry: StatEntry, retryCount: Int = 0) {
         self.id = UUID()
         self.operationType = operationType
@@ -82,10 +88,14 @@ struct SyncOperation: Codable, Identifiable {
         self.createdAt = Date()
         self.retryCount = retryCount
         self.backendId = entry.backendId
+        self.uuid = entry.uuid ?? entry.id.uuidString
+        self.clientLastUpdatedAt = entry.lastUpdatedAt
+        self.isDeleted = entry.isDeleted
+        self.unit = entry.unit ?? entry.type.unit
     }
 }
 
-// MARK: - Backend API Models
+// MARK: - Backend API Models (Legacy)
 struct CreateMetricRequest: Codable {
     let metric_type_id: Int
     let value: Double
@@ -129,7 +139,7 @@ struct MetricResponse: Codable {
     let error: String?
 }
 
-// MARK: - Metrics Fetching Models
+// MARK: - Metrics Fetching Models (Legacy)
 struct MetricsListResponse: Codable {
     let success: Bool
     let entries: [MetricData]
@@ -148,6 +158,83 @@ struct MetricData: Codable {
     let user_id: Int?
     let created_at: String?
     let updated_at: String?
+}
+
+// MARK: - V2 Mobile Sync Models
+struct MobileMetricEntryDTO: Codable {
+    let id: String
+    let metric_type: String?
+    let metric_type_id: Int?
+    let value: Double
+    let unit: String?
+    let timestamp: String?
+    let date: String?
+    let source: String?
+    let last_updated_at: String?
+    let is_deleted: Bool?
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(String.self, forKey: .id)
+        self.metric_type = try container.decodeIfPresent(String.self, forKey: .metric_type)
+        self.metric_type_id = try container.decodeIfPresent(Int.self, forKey: .metric_type_id)
+        // value may come as number or string; handle both
+        if let doubleValue = try? container.decode(Double.self, forKey: .value) {
+            self.value = doubleValue
+        } else if let stringValue = try? container.decode(String.self, forKey: .value), let doubleValue = Double(stringValue) {
+            self.value = doubleValue
+        } else {
+            self.value = 0
+        }
+        self.unit = try container.decodeIfPresent(String.self, forKey: .unit)
+        self.timestamp = try container.decodeIfPresent(String.self, forKey: .timestamp)
+        self.date = try container.decodeIfPresent(String.self, forKey: .date)
+        self.source = try container.decodeIfPresent(String.self, forKey: .source)
+        self.last_updated_at = try container.decodeIfPresent(String.self, forKey: .last_updated_at)
+        self.is_deleted = try container.decodeIfPresent(Bool.self, forKey: .is_deleted)
+    }
+}
+
+struct SyncChangesResponseV2: Codable {
+    let entries: [MobileMetricEntryDTO]
+    let has_more: Bool
+    let server_timestamp: String
+}
+
+struct CreateMetricV2Request: Codable {
+    let id: String?
+    let metric_type: String?
+    let metric_type_id: Int?
+    let value: Double
+    let unit: String?
+    let timestamp: String?
+    let date: String?
+    let source: String
+}
+
+struct UpdateMetricV2Request: Codable {
+    let value: Double?
+    let unit: String?
+    let timestamp: String?
+    let source: String?
+    let client_last_updated_at: String
+}
+
+// MARK: - Date Helpers
+enum DateCoding {
+    static let iso8601: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
+    
+    static let iso8601NoFraction: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        f.timeZone = TimeZone(secondsFromGMT: 0)
+        return f
+    }()
 }
 
 // MARK: - Sync Status

--- a/LifeTrackerX/Models/StatEntry.swift
+++ b/LifeTrackerX/Models/StatEntry.swift
@@ -25,12 +25,88 @@ struct StatEntry: Identifiable, Codable {
     var source: StatSource
     var backendId: Int? // Backend database ID for sync operations
     
-    init(id: UUID = UUID(), date: Date, value: Double, type: StatType, source: StatSource = .manual, backendId: Int? = nil) {
+    // Sync-friendly fields
+    var uuid: String? // Apple Health UUID or client-generated stable id for backend
+    var lastUpdatedAt: Date
+    var syncedWithHealth: Bool
+    var syncedWithBackend: Bool
+    var isDeleted: Bool
+    var unit: String?
+    
+    init(
+        id: UUID = UUID(),
+        date: Date,
+        value: Double,
+        type: StatType,
+        source: StatSource = .manual,
+        backendId: Int? = nil,
+        uuid: String? = nil,
+        lastUpdatedAt: Date = Date(),
+        syncedWithHealth: Bool = false,
+        syncedWithBackend: Bool = false,
+        isDeleted: Bool = false,
+        unit: String? = nil
+    ) {
         self.id = id
         self.date = date
         self.value = value
         self.type = type
         self.source = source
         self.backendId = backendId
+        self.uuid = uuid
+        self.lastUpdatedAt = lastUpdatedAt
+        self.syncedWithHealth = syncedWithHealth
+        self.syncedWithBackend = syncedWithBackend
+        self.isDeleted = isDeleted
+        self.unit = unit
+    }
+    
+    // Backward-compatible Codable implementation (supports old saved data without new fields)
+    enum CodingKeys: String, CodingKey {
+        case id, date, value, type, source, backendId
+        case uuid, lastUpdatedAt, syncedWithHealth, syncedWithBackend, isDeleted, unit
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.date = try container.decode(Date.self, forKey: .date)
+        self.value = try container.decode(Double.self, forKey: .value)
+        self.type = try container.decode(StatType.self, forKey: .type)
+        self.source = try container.decode(StatSource.self, forKey: .source)
+        self.backendId = try container.decodeIfPresent(Int.self, forKey: .backendId)
+        
+        // New fields with safe defaults for legacy data
+        self.uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
+        self.lastUpdatedAt = try container.decodeIfPresent(Date.self, forKey: .lastUpdatedAt) ?? Date()
+        self.syncedWithHealth = try container.decodeIfPresent(Bool.self, forKey: .syncedWithHealth) ?? (self.source == .appleHealth)
+        self.syncedWithBackend = try container.decodeIfPresent(Bool.self, forKey: .syncedWithBackend) ?? false
+        self.isDeleted = try container.decodeIfPresent(Bool.self, forKey: .isDeleted) ?? false
+        self.unit = try container.decodeIfPresent(String.self, forKey: .unit)
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(date, forKey: .date)
+        try container.encode(value, forKey: .value)
+        try container.encode(type, forKey: .type)
+        try container.encode(source, forKey: .source)
+        try container.encodeIfPresent(backendId, forKey: .backendId)
+        try container.encodeIfPresent(uuid, forKey: .uuid)
+        try container.encode(lastUpdatedAt, forKey: .lastUpdatedAt)
+        try container.encode(syncedWithHealth, forKey: .syncedWithHealth)
+        try container.encode(syncedWithBackend, forKey: .syncedWithBackend)
+        try container.encode(isDeleted, forKey: .isDeleted)
+        try container.encodeIfPresent(unit, forKey: .unit)
+    }
+    
+    // Convenience mapping for backend source string
+    var backendSource: String {
+        switch source {
+        case .appleHealth: return "apple_health"
+        case .manual: return "app"
+        case .automated: return "app"
+        }
     }
 }


### PR DESCRIPTION
Implement new mobile sync architecture for metric entries to support robust offline-first sync, UUID-based deduplication, conflict resolution, and soft deletes.

This refactors the existing metric handling to align with the backend's mobile-sync API, addressing previous sync bugs and improving the seamless connection between the iOS app, HealthKit, and the backend. Key changes include extending `StatEntry` with sync metadata, introducing V2 DTOs, implementing soft deletes, and adding conflict resolution based on `lastUpdatedAt` timestamps.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c57abd1-4e18-4678-a20a-0f4a022b3db4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c57abd1-4e18-4678-a20a-0f4a022b3db4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

